### PR TITLE
Fix some pylint, flake8, shellcheck issues and add basic CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,15 @@
+name: cloud-utils ci
+
+on: [push, pull_request]
+
+jobs:
+  tox:
+    # Run on the oldest supported LTS
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Install dependencies
+        run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install tox
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Run tox
+        run: tox

--- a/bin/ec2metadata
+++ b/bin/ec2metadata
@@ -27,7 +27,7 @@ try:
     from urllib import request as urllib_request
     from urllib import error as urllib_error
     from urllib import parse as urllib_parse
-except ImportError as e:
+except ImportError:
     # python2
     import urllib2 as urllib_request
     import urllib2 as urllib_error
@@ -103,7 +103,7 @@ class Error(Exception):
     pass
 
 
-class EC2Metadata:
+class EC2Metadata:  # pylint: disable=R0903
     """Class for querying metadata from EC2"""
 
     def __init__(self, burl=instdata_url):

--- a/bin/ec2metadata
+++ b/bin/ec2metadata
@@ -120,13 +120,13 @@ class EC2Metadata:
 
     @staticmethod
     def _test_connectivity(addr, port):
-        for i in range(6):
+        for _ in range(6):
             s = socket.socket()
             try:
                 s.connect((addr, port))
                 s.close()
                 return True
-            except socket.error as e:
+            except socket.error:
                 time.sleep(1)
 
         return False
@@ -221,7 +221,7 @@ def main():
         getopt_metaopts = METAOPTS[:]
         getopt_metaopts.append('help')
         getopt_metaopts.append('url=')
-        opts, args = getopt.gnu_getopt(sys.argv[1:], "hu:", getopt_metaopts)
+        opts, _ = getopt.gnu_getopt(sys.argv[1:], "hu:", getopt_metaopts)
     except getopt.GetoptError as e:
         usage(e)
 

--- a/bin/growpart
+++ b/bin/growpart
@@ -605,7 +605,7 @@ kver_cmp() {
 	n1="$_RET"
 	kver_to_num "$3"
 	n2="$_RET"
-	[ $n1 $op $n2 ]
+	test $n1 $op $n2
 }
 
 rq() {
@@ -625,7 +625,7 @@ rq() {
 	done
 	cmd=${cmd# }
 
-	debug 2 "$rlabel[$label][$_capture]" "$cmd"
+	debug 2 "${rlabel}[$label][$_capture]" "$cmd"
 	[ "$rlabel" = "would-run" ] && return 0
 
 	if [ "${_capture}" = "erronly" ]; then

--- a/bin/write-mime-multipart
+++ b/bin/write-mime-multipart
@@ -119,6 +119,7 @@ def main():
 
     ofile.close()
 
+
 if __name__ == '__main__':
     main()
 

--- a/bin/write-mime-multipart
+++ b/bin/write-mime-multipart
@@ -101,7 +101,7 @@ def main():
 
         outer.attach(msg)
 
-    if options.output is "-":
+    if options.output == "-":
         if hasattr(sys.stdout, "buffer"):
             # We want to write bytes not strings
             ofile = sys.stdout.buffer

--- a/bin/write-mime-multipart
+++ b/bin/write-mime-multipart
@@ -50,7 +50,7 @@ def get_type(fname, deftype):
     else:
         rtype = 'application/octet-stream'
 
-    return(rtype)
+    return rtype
 
 
 def main():

--- a/bin/write-mime-multipart
+++ b/bin/write-mime-multipart
@@ -9,7 +9,7 @@ from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from optparse import OptionParser
+from optparse import OptionParser  # pylint: disable=W0402
 import gzip
 
 COMMASPACE = ', '

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+disable=invalid-name,missing-module-docstring,missing-function-docstring,missing-class-docstring

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,43 @@
+[tox]
+basepython = python3
+recreate = true
+skipsdist = true
+envlist =
+    flake8
+    pylint
+    shellcheck
+
+[common]
+pyfiles =
+    bin/ec2metadata
+    bin/write-mime-multipart
+shfiles =
+    bin/cloud-localds
+    bin/cloud-publish-ubuntu
+    bin/growpart
+    bin/mount-image-callback
+    bin/resize-part-image
+    bin/ubuntu-cloudimg-query
+    bin/vcs-run
+
+[testenv:flake8]
+deps = flake8==3.8.3
+commands = python3 -m flake8 {[common]pyfiles}
+
+[testenv:pylint]
+deps = pylint==2.5.3
+commands = python3 -m pylint {[common]pyfiles}
+
+[testenv:flake8-tip]
+deps = flake8
+commands = python3 -m flake8 {[common]pyfiles}
+
+[testenv:pylint-tip]
+deps = pylint
+commands = python3 -m pylint {[common]pyfiles}
+
+[testenv:shellcheck]
+# 'shellcheck' is not Python, but tox is a usable wrapper to run any kind of
+# tests. Let's use it for common test-run as well for unification purposes.
+deps = shellcheck-py
+commands = shellcheck --severity=error {[common]shfiles}


### PR DESCRIPTION
Add a basic CI job which checks the code against:

 - flake8
 - pylint
 - shellcheck

using tox and fix the errors/warnings spotted by the job itself.