### PR TITLE
CI: use shellcheck from snap and add tools/* to the files to check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,13 +3,26 @@ name: cloud-utils ci
 on: [push, pull_request]
 
 jobs:
-  tox:
+  ci:
     # Run on the oldest supported LTS
     runs-on: ubuntu-16.04
     steps:
       - name: Install dependencies
-        run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install tox
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install tox
+          sudo snap install shellcheck
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Run tox
         run: tox
+      - name: Run shellcheck
+        run: |
+          shellcheck --severity=error \
+              bin/cloud-localds \
+              bin/cloud-publish-ubuntu \
+              bin/growpart \
+              bin/mount-image-callback \
+              bin/resize-part-image \
+              bin/ubuntu-cloudimg-query \
+              bin/vcs-run \
+              tools/*

--- a/tox.ini
+++ b/tox.ini
@@ -11,14 +11,6 @@ envlist =
 pyfiles =
     bin/ec2metadata
     bin/write-mime-multipart
-shfiles =
-    bin/cloud-localds
-    bin/cloud-publish-ubuntu
-    bin/growpart
-    bin/mount-image-callback
-    bin/resize-part-image
-    bin/ubuntu-cloudimg-query
-    bin/vcs-run
 
 [testenv:flake8]
 deps = flake8==3.8.3
@@ -35,9 +27,3 @@ commands = python3 -m flake8 {[common]pyfiles}
 [testenv:pylint-tip]
 deps = pylint
 commands = python3 -m pylint {[common]pyfiles}
-
-[testenv:shellcheck]
-# shellcheck from Xenial is too old and doesn't support the --severity
-# argument. Let's pull the latest version using shellcheck-py.
-deps = shellcheck-py
-commands = shellcheck --severity=error {[common]shfiles}


### PR DESCRIPTION
Changes:
 - Drop the shellcheck environment from tox.ini
 - Install the shellcheck snap in the CI job
 - Run it on all the shell scripts in bin/ and tools/.

 We don't use the shellcheck Ubuntu package because it's too old in Xenial and
 it doesn't support the --severity argument. Using py-shellcheck in tox worked
 nicely but:

 - Not being a Python thing it was a bit out of place in tox.
 - tox commands are not run in a shell and therefore do not support wildcards
   or complex commands. For example it could be nice to make the CI auto-detect
   shellscripts instead of hardcoding a list of files. Doing this in tox would
   likely require a wrapper script, but better not have that extra complexity.