### PR TITLE
New upstream snapshot.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,15 @@
+name: cloud-utils ci
+
+on: [push, pull_request]
+
+jobs:
+  tox:
+    # Run on the oldest supported LTS
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Install dependencies
+        run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install tox
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Run tox
+        run: tox

--- a/bin/ec2metadata
+++ b/bin/ec2metadata
@@ -27,7 +27,7 @@ try:
     from urllib import request as urllib_request
     from urllib import error as urllib_error
     from urllib import parse as urllib_parse
-except ImportError as e:
+except ImportError:
     # python2
     import urllib2 as urllib_request
     import urllib2 as urllib_error
@@ -37,6 +37,12 @@ except ImportError as e:
 instdata_host = "169.254.169.254"
 instdata_ver = "2009-04-04"
 instdata_url = "http://%s/%s" % (instdata_host, instdata_ver)
+
+TOKEN_TTL_SECONDS = 21600
+TOKEN_HEADER = "X-aws-ec2-metadata-token"
+TOKEN_HEADER_TTL = "X-aws-ec2-metadata-token-ttl-seconds"
+
+session_token_url = "http://%s/%s/%s" % (instdata_host, 'latest', 'api/token')
 
 __doc__ = """
 Query and display EC2 metadata.
@@ -103,7 +109,7 @@ class Error(Exception):
     pass
 
 
-class EC2Metadata:
+class EC2Metadata:  # pylint: disable=R0903
     """Class for querying metadata from EC2"""
 
     def __init__(self, burl=instdata_url):
@@ -117,24 +123,37 @@ class EC2Metadata:
         if not self._test_connectivity(addr, port):
             raise Error("could not establish connection to: %s:%s" %
                         (addr, port))
+        self._imdsv2_ensure_token()
 
     @staticmethod
     def _test_connectivity(addr, port):
-        for i in range(6):
+        for _ in range(6):
             s = socket.socket()
             try:
                 s.connect((addr, port))
                 s.close()
                 return True
-            except socket.error as e:
+            except socket.error:
                 time.sleep(1)
 
         return False
 
+    def _imdsv2_ensure_token(self):
+        # Get IMDSv2 session token
+        request = urllib_request.Request(
+            session_token_url,
+            method='PUT',
+            headers={TOKEN_HEADER_TTL: TOKEN_TTL_SECONDS})
+        resp = urllib_request.urlopen(request)
+        self.session_token = resp.read()
+
     def _get(self, uri, decode=True):
         url = "%s/%s" % (self.burl, uri)
         try:
-            resp = urllib_request.urlopen(urllib_request.Request(url))
+            resp = urllib_request.urlopen(
+                urllib_request.Request(
+                    url,
+                    headers={TOKEN_HEADER: self.session_token}))
             value = resp.read()
             if decode:
                 value = value.decode()
@@ -221,7 +240,7 @@ def main():
         getopt_metaopts = METAOPTS[:]
         getopt_metaopts.append('help')
         getopt_metaopts.append('url=')
-        opts, args = getopt.gnu_getopt(sys.argv[1:], "hu:", getopt_metaopts)
+        opts, _ = getopt.gnu_getopt(sys.argv[1:], "hu:", getopt_metaopts)
     except getopt.GetoptError as e:
         usage(e)
 

--- a/bin/growpart
+++ b/bin/growpart
@@ -28,6 +28,7 @@ PART=""
 PT_UPDATE=false
 DRY_RUN=0
 FLOCK_DISK_FD=""
+RESIZE_RESULT=""
 
 SFDISK_VERSION=""
 SFDISK_2_26="22600"
@@ -46,18 +47,21 @@ fail() {
 }
 
 nochange() {
+	RESIZE_RESULT="NOCHANGE"
 	echo "NOCHANGE:" "$@"
-	exit 1
+	return 1
 }
 
 changed() {
+	RESIZE_RESULT="CHANGED"
 	echo "CHANGED:" "$@"
-	exit 0
+	return 0
 }
 
 change() {
+	RESIZE_RESULT="CHANGE"
 	echo "CHANGE:" "$@"
-	exit 0
+	return 0
 }
 
 cleanup() {
@@ -382,11 +386,15 @@ resize_sfdisk() {
 
 	debug 1 "max_end=${max_end} tot=${sector_num} pt_end=${pt_end}" \
 		"pt_start=${pt_start} pt_size=${pt_size}"
-	[ $((${pt_end})) -eq ${max_end} ] &&
+	[ $((${pt_end})) -eq ${max_end} ] && {
 		nochange "partition ${PART} is size ${pt_size}. it cannot be grown"
-	[ $((${pt_end}+(${FUDGE}/$sector_size))) -gt ${max_end} ] &&
+		return
+	}
+	[ $((${pt_end}+(${FUDGE}/$sector_size))) -gt ${max_end} ] && {
 		nochange "partition ${PART} could only be grown by" \
-		"$((${max_end}-${pt_end})) [fudge=$((${FUDGE}/$sector_size))]"
+			"$((${max_end}-${pt_end})) [fudge=$((${FUDGE}/$sector_size))]"
+		return
+	}
 
 	# now, change the size for this partition in ${dump_out} to be the
 	# new size
@@ -437,6 +445,7 @@ resize_sfdisk() {
 	RESTORE_FUNC=""
 
 	changed "${change_info}"
+	return
 
 	# dump_out looks something like:
 	## partition table of /tmp/out.img
@@ -534,11 +543,15 @@ resize_sgdisk() {
 		"pt_size=${pt_size} pt_max=${pt_max} last=${last}"
 
 	# Check if the partition can be grown
-	[ "${pt_end}" -eq "${pt_max}" ] &&
+	[ "${pt_end}" -eq "${pt_max}" ] && {
 		nochange "${dev}: size=${pt_size}, it cannot be grown"
-	[ "$((${pt_end} + ${FUDGE}/${sector_size}))" -gt "${pt_max}" ] &&
+		return
+	}
+	[ "$((${pt_end} + ${FUDGE}/${sector_size}))" -gt "${pt_max}" ] && {
 		nochange "${dev}: could only be grown by" \
-		"$((${pt_max} - ${pt_end})) [fudge=$((${FUDGE}/$sector_size))]"
+			"$((${pt_max} - ${pt_end})) [fudge=$((${FUDGE}/$sector_size))]"
+		return
+	}
 
 	# The partition can be grown if we made it here. Get some more info
 	# about it so we can do it properly.
@@ -583,20 +596,27 @@ resize_sgdisk() {
 	}
 
 	# Dry run
-	[ "${DRY_RUN}" -ne 0 ] && change "${change_info}"
+	[ "${DRY_RUN}" -ne 0 ] && {
+		change "${change_info}"
+		return
+	}
 
 	changed "${change_info}"
+	return
 }
 
 kver_to_num() {
-	local kver="$1" maj="" min="" mic="0"
-	kver=${kver%%-*}
-	maj=${kver%%.*}
-	min=${kver#${maj}.}
-	min=${min%%.*}
-	mic=${kver#${maj}.${min}.}
-	[ "$kver" = "$mic" ] && mic=0
-	_RET=$(($maj*1000*1000+$min*1000+$mic))
+	local kver="$1" maj min mic
+
+	# Canonicalize the kernel version
+	kver=${kver%%[!0-9.]*}.0.0
+
+	maj=${kver%%[!0-9]*}
+	kver=${kver#*.}
+	min=${kver%%[!0-9]*}
+	kver=${kver#*.}
+	mic=${kver%%[!0-9]*}
+	_RET=$((maj*1000*1000+min*1000+mic))
 }
 
 kver_cmp() {
@@ -605,7 +625,7 @@ kver_cmp() {
 	n1="$_RET"
 	kver_to_num "$3"
 	n2="$_RET"
-	[ $n1 $op $n2 ]
+	test $n1 $op $n2
 }
 
 rq() {
@@ -625,7 +645,7 @@ rq() {
 	done
 	cmd=${cmd# }
 
-	debug 2 "$rlabel[$label][$_capture]" "$cmd"
+	debug 2 "${rlabel}[$label][$_capture]" "$cmd"
 	[ "$rlabel" = "would-run" ] && return 0
 
 	if [ "${_capture}" = "erronly" ]; then
@@ -809,6 +829,39 @@ get_resizer() {
 	return 0
 }
 
+maybe_lvm_resize() {
+	local disk="$1" part="$2" partpath="" ret="" out="" wouldrun=""
+	[ "$DRY_RUN" -ne 0 ] && wouldrun="would-run"
+
+	has_cmd lvm || {
+		debug 2 "No lvm command, cannot attempt lvm resize of disk '$disk' part '$part'"
+		return 0
+	}
+	get_diskpart_path "$1" "$2" || {
+		error "could not determine partition path for disk '$DISK' part '$part'"
+		return 1
+	}
+	partpath="$_RET"
+
+	# can't use rq or rqe here because of "not an lvm" exit code 5.
+	set -- lvm pvs --nolocking --readonly -o pvname "$partpath"
+	debug 2 "executing: $*"
+	out=$("$@" 2>&1)
+	ret=$?
+	case "$ret" in
+		5) debug 1 "$partpath is not an lvm pv"; return 0;;
+		0) :;;
+		*) error "failed to execute [$ret] '$*'"
+			error "$out"
+			return 1;;
+	esac
+	rq lvm_resize $wouldrun lvm pvresize "$partpath" || {
+		error "Failed to resize lvm pv $partpath"
+		return 1
+	}
+	return 0
+}
+
 pt_update="auto"
 resizer=${GROWPART_RESIZER:-"auto"}
 while [ $# -ne 0 ]; do
@@ -898,12 +951,20 @@ trap cleanup 0 # EXIT - some shells may not like 'EXIT' but are ok with 0
 get_table_format "$DISK" || fail
 format=$_RET
 get_resizer "$format" "$resizer" ||
-	fail "failed to get a resizer for id '$id'"
+	fail "failed to get a resizer for format '$format'"
 resizer=$_RET
 
 lock_disk $DISK
 debug 1 "resizing $PART on $DISK using $resizer"
 "$resizer"
+ret=$?
+
 unlock_disk_and_settle $DISK
+
+if [ "$RESIZE_RESULT" = "CHANGED" -o "$RESIZE_RESULT" = "CHANGE" ]; then
+	maybe_lvm_resize "$DISK" "$PART" || fail "lvm resize failed."
+fi
+
+exit $ret
 
 # vi: ts=4 noexpandtab

--- a/bin/write-mime-multipart
+++ b/bin/write-mime-multipart
@@ -9,7 +9,7 @@ from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from optparse import OptionParser
+from optparse import OptionParser  # pylint: disable=W0402
 import gzip
 
 COMMASPACE = ', '
@@ -50,7 +50,7 @@ def get_type(fname, deftype):
     else:
         rtype = 'application/octet-stream'
 
-    return(rtype)
+    return rtype
 
 
 def main():
@@ -101,7 +101,7 @@ def main():
 
         outer.attach(msg)
 
-    if options.output is "-":
+    if options.output == "-":
         if hasattr(sys.stdout, "buffer"):
             # We want to write bytes not strings
             ofile = sys.stdout.buffer
@@ -118,6 +118,7 @@ def main():
         ofile.write(outer.as_string().encode())
 
     ofile.close()
+
 
 if __name__ == '__main__':
     main()

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-utils (0.31-22-g37d4e32a-0ubuntu1) UNRELEASED; urgency=medium
+cloud-utils (0.31-22-g37d4e32a-0ubuntu1) groovy; urgency=medium
 
   * New upstream snapshot.
     - Growpart fix undefined variable in growpart error message.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+cloud-utils (0.31-22-g37d4e32a-0ubuntu1) UNRELEASED; urgency=medium
+
+  * New upstream snapshot.
+    - Growpart fix undefined variable in growpart error message.
+    - Add test for growpart lvm resize.
+    - Growpart: add support for resizing an lvm pv after growing the
+      partition. (LP: #1799953)
+    - Make resize functions return, so unlock_disk_and_settle is called.
+    - CI: rename the "tip" tox environments to tip-* [Paride Legovini]
+    - CI: pin the shellcheck version and add a shellcheck-tip environment
+      [Paride Legovini]
+    - CI: make shellcheck check tools/* [Paride Legovini]
+    - IMDSv2 session token support (#1) [Paride Legovini] (LP: #1870244)
+    - growpart: parse the kernel version in a more robust way (#2)
+      [Paride Legovini] (LP: #1881014)
+    - Fix some pylint, flake8, shellcheck issues and add basic CI (#4)
+      [Paride Legovini]
+
+ -- Scott Moser <smoser@ubuntu.com>  Tue, 21 Jul 2020 09:39:36 -0400
+
 cloud-utils (0.31-12-g3d6d5128-0ubuntu1) groovy; urgency=medium
 
   * New upstream snapshot.

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,6 +1,6 @@
-Tests: growpart-loop
+Tests: growpart-loop, growpart-lvm
 Restrictions: needs-root isolation-machine allow-stderr
-Depends: cloud-guest-utils, fdisk, gdisk
+Depends: cloud-guest-utils, fdisk, gdisk, lvm2
 
 Tests: growpart-fsimage, growpart-fsimage-middle, growpart-start-matches-size
 Restrictions: allow-stderr

--- a/debian/tests/growpart-lvm
+++ b/debian/tests/growpart-lvm
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+my_d=$(dirname "$0")
+. "$my_d/functions" || { echo "failed to source functions" 1>&2; exit 1; }
+
+runtests ./test/test-growpart-lvm
+# vi: ts=4 expandtab

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+disable=invalid-name,missing-module-docstring,missing-function-docstring,missing-class-docstring

--- a/test/test-growpart-lvm
+++ b/test/test-growpart-lvm
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+set -e
+
+[ "$(id -u)" = "0" ] ||
+	{ echo "sorry, must be root"; exit 1; }
+
+PT_TYPE="${PT_TYPE:-dos}" # dos or gpt
+size=${DISK_SIZE_NEW:-1000M}
+osize=${DISK_SIZE_ORIG:-500M}
+
+PV=""
+VG=""
+MP=""
+LODEV=""
+TEMP_D=""
+
+rqerror() {
+	# run, capture error only. show error on non-zero.
+	# lvm puts non-error output to stderr, (open failed: no medium found)
+	# and can't be told to only show errors (--quiet doesnt work).
+	local err="${TEMP_D}/err" ret=""
+	"$@" 2>"$err"
+	ret=$?
+	if [ $ret -ne 0 ]; then
+		cat "$err" 1>&2
+	fi
+	return $ret
+}
+
+rq() {
+   local out="${TEMP_D}/out"
+	"$@" > "$out" 2>&1 || { echo "FAILED:" "$@"; cat "$out"; return 1; }
+}
+
+clearparts() {
+	# read /proc/partitions, clearing any partitions on dev (/dev/loopX)
+	local dev="$1"
+	local short=${dev##*/} parts="" part=""
+	parts=$(awk '$4 ~ m { sub(m,"",$4); print $4 }' \
+		"m=${short}p" /proc/partitions)
+	[ -z "$parts" ] && return
+	echo "clearing parts [$parts] from $dev"
+	for part in $parts; do
+		echo "delpart $LODEV $part"
+		delpart $LODEV $part
+	done
+	udevadm settle
+}
+cleanup() {
+	if [ -n "$MP" ]; then
+		echo "unmount $MP";
+		umount "$MP";
+		udevadm settle
+	fi
+	if [ -n "$VG" ]; then
+		echo "removing vg $VG"
+		rq lvm vgremove --force --yes "$VG"
+	fi
+	if [ -n "$PV" ]; then
+		echo "removing pv $PV"
+		rq lvm pvremove --force --yes "$PV"
+		udevadm settle
+	fi
+	if [ -n "$LODEV" ]; then
+		clearparts "$LODEV"
+		echo "losetup --detach $LODEV";
+		losetup --detach "$LODEV";
+		udevadm settle
+	fi
+	[ ! -d "${TEMP_D}" ] || rm -Rf "${TEMP_D}"
+}
+rq() {
+   local out="${TEMP_D}/out"
+	"$@" > "$out" 2>&1 || { echo "FAILED:" "$@"; cat "$out"; return 1; }
+}
+
+get_vgsize() {
+	local vg="$1" out=""
+	out=$(export LC_ALL=C; rqerror lvm vgs "$vg" --units=m --noheadings --options=vgsize) || return
+	out=$(echo "$out" | sed 's,[ ],,g') # output has extra whitespace
+	out=${out%m} # and of course a unit.
+	out=${out%.*} # and floating point - helpful
+	_RET="$out"
+}
+
+TEMP_D=$(mktemp -d ${TMPDIR:-/tmp}/${0##*/}.XXXXXX)
+trap cleanup EXIT
+
+img="${TEMP_D}/disk.img"
+mp="${TEMP_D}/mp"
+
+echo "Partitioning $PT_TYPE orig_size=$osize grow_size=$size."
+echo "growpart is $(which growpart)"
+rm -f $img
+[ ! -e $mp ] || rmdir $mp || { echo "failed rmdir $mp"; exit 1; }
+mkdir $mp
+
+truncate --size $osize "$img"
+
+label_flag="--label=${PT_TYPE}"
+echo "2048," | rq sfdisk $label_flag --force --unit=S "$img"
+
+truncate --size "$size" "$img"
+
+lodev=$(losetup --show --find "$img")
+LODEV=$lodev
+echo "set up $lodev"
+
+# clear any old ones that might be around (LP: #1136781)
+clearparts "$lodev"
+partx --add $lodev
+lodevpart="${lodev}p1"
+
+vg="testvg-$$"
+rqerror lvm pvcreate --quiet "$lodevpart"
+PV="$lodevpart"
+rqerror lvm vgcreate "$vg" "$lodevpart"
+VG="$vg"
+
+echo "==== before ===="
+get_vgsize "$vg"
+vgsize_before=$_RET
+echo "=== size=${vgsize_before}."
+rqerror lvm vgdisplay "$vg" 2>/dev/null
+
+# uses DM_DISABLE_UDEV to speed things up.
+# otherwise, lvm resize will poll on udev (/run/udev/data/b259:7)
+# things and take some time.  Even lvm pvs --nolocking --readonly.
+DM_DISABLE_UDEV=1 growpart -v -v "$lodev" 1
+
+echo "==== after ===="
+rqerror lvm vgdisplay "$vg" 2>/dev/null
+get_vgsize "$vg"
+echo "=== size=$_RET."
+vgsize_after=$_RET
+
+echo "size before=$vgsize_before after=$vgsize_after"
+if [ "$vgsize_before" -lt "$vgsize_after" ]; then
+	echo "PASS - grew $((vgsize_after-$vgsize_before))MiB"
+else
+	echo "FAIL - didn't grow vg $vg" 1>&2
+	exit 1
+fi
+
+
+# vi: ts=4 noexpandtab

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,51 @@
+[tox]
+basepython = python3
+recreate = true
+skipsdist = true
+envlist =
+    flake8
+    pylint
+    shellcheck
+
+[common]
+pyfiles =
+    bin/ec2metadata
+    bin/write-mime-multipart
+shfiles =
+    bin/cloud-localds
+    bin/cloud-publish-ubuntu
+    bin/growpart
+    bin/mount-image-callback
+    bin/resize-part-image
+    bin/ubuntu-cloudimg-query
+    bin/vcs-run
+    tools/build-deb
+    tools/make-short-partition
+    tools/make-tarball
+
+[testenv:flake8]
+deps = flake8==3.8.3
+commands = python3 -m flake8 {[common]pyfiles}
+
+[testenv:pylint]
+deps = pylint==2.5.3
+commands = python3 -m pylint {[common]pyfiles}
+
+[testenv:shellcheck]
+# shellcheck from Xenial is too old and doesn't support the --severity
+# argument; let's pull a newer version using shellcheck-py. This also
+# allows to pin the shellcheck version we check against.
+deps = shellcheck-py==0.7.1.1
+commands = shellcheck --severity=error {[common]shfiles}
+
+[testenv:tip-flake8]
+deps = flake8
+commands = python3 -m flake8 {[common]pyfiles}
+
+[testenv:tip-pylint]
+deps = pylint
+commands = python3 -m pylint {[common]pyfiles}
+
+[testenv:tip-shellcheck]
+deps = shellcheck-py
+commands = shellcheck --severity=error {[common]shfiles}


### PR DESCRIPTION
cloud-utils (0.31-22-g37d4e32a-0ubuntu1) groovy; urgency=medium

  * New upstream snapshot.
    - Growpart fix undefined variable in growpart error message.
    - Add test for growpart lvm resize.
    - Growpart: add support for resizing an lvm pv after growing the
      partition. ([LP: #1799953](https://bugs.launchpad.net/bugs/1799953))
    - Make resize functions return, so unlock_disk_and_settle is called.
    - CI: rename the "tip" tox environments to tip-* [Paride Legovini]
    - CI: pin the shellcheck version and add a shellcheck-tip environment
      [Paride Legovini]
    - CI: make shellcheck check tools/* [Paride Legovini]
    - IMDSv2 session token support (#1) [Paride Legovini] ([LP: #1870244](https://bugs.launchpad.net/bugs/1870244))
    - growpart: parse the kernel version in a more robust way (#2)
      [Paride Legovini] ([LP: #1881014](https://bugs.launchpad.net/bugs/1881014))
    - Fix some pylint, flake8, shellcheck issues and add basic CI (#4)
      [Paride Legovini]

 -- Scott Moser <smoser@ubuntu.com>  Tue, 21 Jul 2020 09:39:36 -0400