### PR TITLE
Fix bad variable use.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,12 +4,16 @@ on: [push, pull_request]
 
 jobs:
   tox:
-    # Run on the oldest supported LTS
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
+      - name: Update apt
+        run: sudo apt-get update -q
       - name: Install dependencies
-        run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install tox
+        run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install tox lvm2 fdisk gdisk qemu-utils
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Run tox
         run: tox
+      - name: Run tests
+        # SKIP growpart-lvm test that does not work on github c-i
+        run: sudo SKIP=growpart-lvm PATH=$PWD/bin:$PATH ./test/run-all

--- a/bin/growpart
+++ b/bin/growpart
@@ -175,7 +175,7 @@ unlock_disk_and_settle() {
 	# FLOCK_DISK_FD is set to the hard-coded value of 9.
 	# After unlocking run udevadm settle as the disk has likely been changed.
 	[ "${DRY_RUN}" = 0 ] || return
-	[ -n "${FLOCK_DEVICE_FD}" ] || return
+	[ -n "${FLOCK_DISK_FD}" ] || return
 
 	debug 1 "FLOCK: ${disk}: releasing exclusive lock"
 	exec 9>&-

--- a/test/run-all
+++ b/test/run-all
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+id=$(id -u)
+
+needs_root() {
+    grep -q NEED_ROOT "$1"
+}
+
+
+tests=( )
+for t in ./test/test-*; do
+    [ -x "$t" ] && [ -f "$t" ] && tests[${#tests[@]}]="$t"
+done
+
+if [ "$id" != "0" ]; then
+    echo "not root, (id=$id), only executing subset of tests."
+fi
+
+passes=( )
+skips=( )
+fails=( )
+
+# allow environment to specify , separated list of tests to skip
+skiptests=",$SKIP,"
+
+for t in "${tests[@]}"; do
+    name=${t##*/}
+    short=${name#test-}
+    if [ "$id" != "0" ] && needs_root "$t"; then
+        skips[${#skips[@]}]="$name"
+        echo "$name: SKIP (not root)"
+        continue
+    fi
+    case "$skiptests" in
+        *,$name,*|*,$short,*)
+            echo "$name: SKIP (environ)"
+            skips[${#skips[@]}]="$name"
+            continue
+            ;;
+    esac
+    # send test output to stderr, so it can all be redirected.
+    "$t" 1>&2
+    r=$?
+    if [ $r -eq 0 ]; then
+        echo "$name: PASS"
+        passes[${#passes[@]}]="$name"
+    else
+        echo "$name: FAIL"
+        fails[${#fails[@]}]="$name"
+    fi
+done
+
+echo "== results =="
+echo "${#passes[@]} passed. ${#fails[@]} failed. ${#skips[@]} skipped."
+echo "PASSES: ${passes[*]}"
+echo "FAILS: ${fails[*]}"
+echo "SKIP: ${skips[*]}"
+
+if [ "${#fails[@]}" != "0" ] && [ "${#passes[@]}" != "0" ]; then
+    exit 1
+fi
+exit 0

--- a/test/test-growpart
+++ b/test/test-growpart
@@ -1,4 +1,5 @@
 #!/bin/bash
+# NEED_ROOT
 
 set -e
 

--- a/test/test-growpart
+++ b/test/test-growpart
@@ -84,7 +84,22 @@ echo "==== before ===="
 grep "${lodev##*/}" /proc/partitions
 sfdisk --list --unit=S "$lodev"
 
-growpart -v -v "$lodev" 1
+errfile="${TEMP_D}/growpart.err"
+growpart -v -v "$lodev" 1 2>"$errfile" || {
+	rc=$?
+	echo "failed [$rc]: growpart -v -v $lodev 1"
+	cat "$errfile" 1>&2
+	exit $rc
+}
+
+out=$(grep "FLOCK:.*releasing exclusive lock" "$errfile") || :
+if [ -z "$out" ]; then
+	echo "ERROR: growpart stderr did not mention releasing lock"
+	exit 1
+fi
+
+echo === growpart stderr ===
+cat "$errfile"
 
 echo "==== after ===="
 grep "${lodev##*/}" /proc/partitions

--- a/test/test-growpart-lvm
+++ b/test/test-growpart-lvm
@@ -1,4 +1,5 @@
 #!/bin/bash
+# NEED_ROOT
 
 set -e
 

--- a/test/test-mic
+++ b/test/test-mic
@@ -1,4 +1,5 @@
 #!/bin/bash
+# NEED_ROOT
 
 set -e
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ shfiles =
     test/test-growpart-lvm
     test/test-growpart-start-matches-size
     test/test-mic
+    test/run-all
     tools/build-deb
     tools/make-short-partition
     tools/make-tarball


### PR DESCRIPTION
Fix bad variable name, enable tests in c-i.

As found by laney in a cloud-initramfs merge proposal,
FLOCK_DEVICE_FD != FLOCK_DISK_ID.

FLOCK_DEVICE_FD would never be set, so we would always
return from unlock_disk_and_settle and never either:
 * close the device
 * settle.

Also, enable tests to run in c-i via the newly added './test/run-all'.
