### PR TITLE
Harden test growpart

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,8 @@ Build-Depends: debhelper-compat (= 13), dh-python, python3
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://launchpad.net/cloud-utils
+Vcs-Browser: https://github.com/canonical/cloud-utils
+Vcs-Git: https://github.com/canonical/cloud-utils.git
 
 Package: cloud-utils
 Architecture: all

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,4 @@
-version=3
-https://launchpad.net/cloud-utils/+download/ https://launchpad.net/cloud-utils/.*/cloud-utils-([\d\.]+)\.tar\.gz
+version=4
+opts="filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%cloud-utils-$1.tar.gz%" \
+    https://github.com/canonical/cloud-utils/tags \
+    (?:.*?/)?v?(\d[\d.]*)\.tar\.gz debian uupdate


### PR DESCRIPTION
Example [failing log](https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-hirsute/hirsute/arm64/c/cloud-utils/20210107_161643_5a169@/log.gz).

[These logs](https://autopkgtest.ubuntu.com/packages/c/cloud-utils/hirsute/arm64) shows that they fail only "sometimes" and "in different places" so it is not one particular function that is bad.
Just overall race to be unable to `delpart` right after the `umount`.