### PR TITLE
growpart test: use losetup --partscan/--detach to handle the lodev parts

### DIFF
--- a/test/test-growpart
+++ b/test/test-growpart
@@ -14,31 +14,14 @@ MP=""
 LODEV=""
 TEMP_D=""
 
-clearparts() {
-	# read /proc/partitions, clearing any partitions on dev (/dev/loopX)
-	local dev="$1"
-	local short=${dev##*/} parts="" part=""
-	parts=$(awk '$4 ~ m { sub(m,"",$4); print $4 }' \
-		"m=${short}p" /proc/partitions)
-	[ -z "$parts" ] && return
-	echo "clearing parts [$parts] from $dev"
-	for part in $parts; do
-		echo "delpart $LODEV $part"
-		delpart $LODEV $part
-	done
-	udevadm settle
-}
 cleanup() {
 	if [ -n "$MP" ]; then
 		echo "unmount $MP";
 		umount "$MP";
-		udevadm settle
 	fi
 	if [ -n "$LODEV" ]; then
-		clearparts "$LODEV"
 		echo "losetup --detach $LODEV";
 		losetup --detach "$LODEV";
-		udevadm settle
 	fi
 	[ ! -d "${TEMP_D}" ] || rm -Rf "${TEMP_D}"
 }
@@ -66,13 +49,9 @@ echo "2048," | rq sfdisk $label_flag --force --unit=S "$img"
 
 truncate --size "$size" "$img"
 
-lodev=$(losetup --show --find "$img")
+lodev=$(losetup --show --find --partscan "$img")
 LODEV=$lodev
 echo "set up $lodev"
-
-# clear any old ones that might be around (LP: #1136781)
-clearparts "$lodev"
-partx --add $lodev
 lodevpart="${lodev}p1"
 
 rq mkfs.ext4 "${lodevpart}"


### PR DESCRIPTION
It seems that the test/test-growpart "clearparts" logic was added as a
workaround for LP: #1136781. As of today on a Hirsute system running
Linux 5.8.0-1014-kvm the behavior is still the same described in the bug
report, however I noticed that when the loop device partitions are
scanned at losetup time via `losetup --partscan`, then the discovered
partitions are removed at `losetup --detach` time. In contrast, if the
partitions are scanned via `partx /dev/loopX` or `partscan /dev/loopX`,
then they are not removed by `losetup --detach`, which is what the bug
report is about.

I can't tell why the two ways of scanning partitions yield to a
different behavior in `losetup --detach`. Does `losetup --partscan`
track the partitions it "owns" somewhere, and deletes only those? I
couldn't find this documented anywhere, however the partition deletion
works consistently and reliably.

Using losetup --partscan/--detach to handle the partitions also removes
the umount/delpart race that was worked around in 51ef36d by
adding a `udevadm settle` call, which we can now remove. The same race
recently started showing up on arm64, which is what prompted this work.