### PR TITLE
test-growpart: udevadm settle after setting up the loop device

### DIFF
--- a/test/test-growpart
+++ b/test/test-growpart
@@ -51,6 +51,7 @@ truncate --size "$size" "$img"
 
 lodev=$(losetup --show --find --partscan "$img")
 LODEV=$lodev
+udevadm settle
 echo "set up $lodev"
 lodevpart="${lodev}p1"
 


### PR DESCRIPTION
Commit message copypaste:

`losetup --show --find --partscan` automatically scans for partitions in
the loopback device, triggering the generation of kernel events that
result in the creation of /dev/loopXpY files via udev. This is however
asynchronous, and the /dev/loopXpY files may not exist immediately after
losetup returns, making the test racey. Calling `udevadm settle` ensures
that all the files are in place before the script proceeds.