### PR TITLE
growpart: Use LANG=C to parse sfdisk output

### DIFF
--- a/bin/growpart
+++ b/bin/growpart
@@ -292,7 +292,7 @@ resize_sfdisk() {
 	local pt_start pt_size pt_end max_end new_size change_info dpart
 	local sector_num sector_size disk_size tot out
 
-	rqe sfd_list sfdisk --list --unit=S "$DISK" >"$tmp" ||
+	LANG=C rqe sfd_list sfdisk --list --unit=S "$DISK" >"$tmp" ||
 		fail "failed: sfdisk --list $DISK"
 	if [ "${SFDISK_VERSION}" -lt ${SFDISK_2_26} ]; then
 		# exected output contains: Units: sectors of 512 bytes, ...


### PR DESCRIPTION
This will prevent failure to parse output of in non-C locales leading to
failure to resize partition.

Alternative would be to use sfdisk --dump, but this misses some
importants informations such as the sectors size

Reported in:
https://bugs.launchpad.net/cloud-utils/+bug/1860479

This was tested on centos7 with sfdisk 2.23.2 and
centos8 with sfdisk 2.32.1

Reported-by: https://launchpad.net/~pickadi
Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>