### PR TITLE
Merge test changes from test-growpart to test-growpart-lvm

### DIFF
--- a/test/test-growpart-lvm
+++ b/test/test-growpart-lvm
@@ -34,25 +34,10 @@ rq() {
 	"$@" > "$out" 2>&1 || { echo "FAILED:" "$@"; cat "$out"; return 1; }
 }
 
-clearparts() {
-	# read /proc/partitions, clearing any partitions on dev (/dev/loopX)
-	local dev="$1"
-	local short=${dev##*/} parts="" part=""
-	parts=$(awk '$4 ~ m { sub(m,"",$4); print $4 }' \
-		"m=${short}p" /proc/partitions)
-	[ -z "$parts" ] && return
-	echo "clearing parts [$parts] from $dev"
-	for part in $parts; do
-		echo "delpart $LODEV $part"
-		delpart $LODEV $part
-	done
-	udevadm settle
-}
 cleanup() {
 	if [ -n "$MP" ]; then
 		echo "unmount $MP";
 		umount "$MP";
-		udevadm settle
 	fi
 	if [ -n "$VG" ]; then
 		echo "removing vg $VG"
@@ -61,13 +46,10 @@ cleanup() {
 	if [ -n "$PV" ]; then
 		echo "removing pv $PV"
 		rq lvm pvremove --force --yes "$PV"
-		udevadm settle
 	fi
 	if [ -n "$LODEV" ]; then
-		clearparts "$LODEV"
 		echo "losetup --detach $LODEV";
 		losetup --detach "$LODEV";
-		udevadm settle
 	fi
 	[ ! -d "${TEMP_D}" ] || rm -Rf "${TEMP_D}"
 }
@@ -104,13 +86,10 @@ echo "2048," | rq sfdisk $label_flag --force --unit=S "$img"
 
 truncate --size "$size" "$img"
 
-lodev=$(losetup --show --find "$img")
+lodev=$(losetup --show --find --partscan "$img")
 LODEV=$lodev
+udevadm settle
 echo "set up $lodev"
-
-# clear any old ones that might be around (LP: #1136781)
-clearparts "$lodev"
-partx --add $lodev
 lodevpart="${lodev}p1"
 
 vg="testvg-$$"


### PR DESCRIPTION
Currently, test-growpart-lvm is flaky in autopkgtest, and I have been
able to reproduce that reasonably well.  (100% in local qemu
autopkgtest, 15% in direct invocation of the failing test)

Symptom:
delpart: failed to remove partition: Device or resource busy

A "sleep 1" before delpart reliably worked around this,
but let's not go there.

Recent changes to test-growpart also address the issue if merged here.
This brings over these commits to this file, more or less:
* 1520f840f377dc00ddd605652f37113a3e89c154
* 5b59de87d61432442883a8181b0d8999fe6285d4

LP: #1929885