### PR TITLE
New upstream snapshot: 0.32-22-g45fe84a5-0ubuntu1

### DIFF
--- a/bin/growpart
+++ b/bin/growpart
@@ -162,7 +162,7 @@ lock_disk() {
 	# Do not use --nonblock or --timeout as udev may be already processing
 	# the disk and we must wait until it has released the disk to
 	# proceed.  Failure to obtain exclusive lock is fatal to growpart.
-	rq flock flock --exclusive $FLOCK_DISK_FD ||
+	rq flock flock -x $FLOCK_DISK_FD ||
 		fail "Error while obtaining exclusive lock on $DISK"
 	debug 1 "FLOCK: $disk: obtained exclusive lock"
 }
@@ -230,7 +230,7 @@ get_sfdisk_version() {
 		return 0
 	}
 	# expected output: sfdisk from util-linux 2.25.2
-	out=$(sfdisk --version) ||
+	out=$(LANG=C sfdisk --version) ||
 		{ error "failed to get sfdisk version"; return 1; }
 	set -- $out
 	ver=$4
@@ -292,7 +292,7 @@ resize_sfdisk() {
 	local pt_start pt_size pt_end max_end new_size change_info dpart
 	local sector_num sector_size disk_size tot out
 
-	rqe sfd_list sfdisk --list --unit=S "$DISK" >"$tmp" ||
+	LANG=C rqe sfd_list sfdisk --list --unit=S "$DISK" >"$tmp" ||
 		fail "failed: sfdisk --list $DISK"
 	if [ "${SFDISK_VERSION}" -lt ${SFDISK_2_26} ]; then
 		# exected output contains: Units: sectors of 512 bytes, ...

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+cloud-utils (0.32-22-g45fe84a5-0ubuntu1) UNRELEASED; urgency=medium
+
+  * New upstream snapshot.
+    - Merge test changes from test-growpart to test-growpart-lvm
+      [Dan Bungert] (LP: #1929885)
+    - Fix issue LP: #1928167 growpart doesn't work when LANG=cs_CZ.UTF-8
+      [Amy Chen]
+    - growpart: change flock call to use short option for Busybox
+      compatibility [Dermot Bradley]
+    - growpart: Use LANG=C to parse sfdisk output [Nicolas Chauvet]
+      (LP: #1860479)
+
+ -- Paride Legovini <paride@ubuntu.com>  Thu, 05 Aug 2021 11:58:37 +0200
+
 cloud-utils (0.32-18-g5b59de87-0ubuntu1) hirsute; urgency=medium
 
   * New upstream snapshot.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-utils (0.32-22-g45fe84a5-0ubuntu1) UNRELEASED; urgency=medium
+cloud-utils (0.32-22-g45fe84a5-0ubuntu1) impish; urgency=medium
 
   * New upstream snapshot.
     - Merge test changes from test-growpart to test-growpart-lvm

--- a/test/test-growpart-lvm
+++ b/test/test-growpart-lvm
@@ -34,25 +34,10 @@ rq() {
 	"$@" > "$out" 2>&1 || { echo "FAILED:" "$@"; cat "$out"; return 1; }
 }
 
-clearparts() {
-	# read /proc/partitions, clearing any partitions on dev (/dev/loopX)
-	local dev="$1"
-	local short=${dev##*/} parts="" part=""
-	parts=$(awk '$4 ~ m { sub(m,"",$4); print $4 }' \
-		"m=${short}p" /proc/partitions)
-	[ -z "$parts" ] && return
-	echo "clearing parts [$parts] from $dev"
-	for part in $parts; do
-		echo "delpart $LODEV $part"
-		delpart $LODEV $part
-	done
-	udevadm settle
-}
 cleanup() {
 	if [ -n "$MP" ]; then
 		echo "unmount $MP";
 		umount "$MP";
-		udevadm settle
 	fi
 	if [ -n "$VG" ]; then
 		echo "removing vg $VG"
@@ -61,13 +46,10 @@ cleanup() {
 	if [ -n "$PV" ]; then
 		echo "removing pv $PV"
 		rq lvm pvremove --force --yes "$PV"
-		udevadm settle
 	fi
 	if [ -n "$LODEV" ]; then
-		clearparts "$LODEV"
 		echo "losetup --detach $LODEV";
 		losetup --detach "$LODEV";
-		udevadm settle
 	fi
 	[ ! -d "${TEMP_D}" ] || rm -Rf "${TEMP_D}"
 }
@@ -104,13 +86,10 @@ echo "2048," | rq sfdisk $label_flag --force --unit=S "$img"
 
 truncate --size "$size" "$img"
 
-lodev=$(losetup --show --find "$img")
+lodev=$(losetup --show --find --partscan "$img")
 LODEV=$lodev
+udevadm settle
 echo "set up $lodev"
-
-# clear any old ones that might be around (LP: #1136781)
-clearparts "$lodev"
-partx --add $lodev
 lodevpart="${lodev}p1"
 
 vg="testvg-$$"


### PR DESCRIPTION
- growpart: Use LANG=C to parse sfdisk output
- growpart: change flock call to use short option for Busybox compatibility
- Fix issue LP: #1928167 growpart doesn't work when LANG=cs_CZ.UTF-8
- Merge test changes from test-growpart to test-growpart-lvm
- update changelog (New upstream snapshot 0.32-22-g45fe84a5).
- releasing cloud-utils version 0.32-22-g45fe84a5-0ubuntu1
