### PR TITLE
d/control: set Maintainer to Ubuntu Developers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: cloud-utils
 Section: admin
 Priority: optional
-Maintainer: Scott Moser <smoser@ubuntu.com>
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper-compat (= 13), dh-python, python3
 Standards-Version: 4.5.0
 Rules-Requires-Root: no


### PR DESCRIPTION
The package is maintained by the Server Team together with cloud-init.
Update the Maintainer field to reflect this.
