### PR TITLE
Only run `udevadm` if it exists

### DIFF
--- a/bin/growpart
+++ b/bin/growpart
@@ -179,7 +179,7 @@ unlock_disk_and_settle() {
 
 	debug 1 "FLOCK: ${disk}: releasing exclusive lock"
 	exec 9>&-
-	[ "${settle}" = 1 ] && udevadm settle
+	[ "${settle}" = 1 ] && has_cmd udevadm && udevadm settle
 	FLOCK_DISK_FD=""
 }
 

--- a/bin/growpart
+++ b/bin/growpart
@@ -173,7 +173,8 @@ unlock_disk_and_settle() {
 	local settle=${2-"1"}
 	# release the lock on a disk if locked.  When a disk is locked,
 	# FLOCK_DISK_FD is set to the hard-coded value of 9.
-	# After unlocking run udevadm settle as the disk has likely been changed.
+	# After unlocking run udevadm settle (if installed) as the disk has
+	# likely been changed.
 	[ "${DRY_RUN}" = 0 ] || return
 	[ -n "${FLOCK_DISK_FD}" ] || return
 


### PR DESCRIPTION
For example OpenWRT doesn't have `udevadm`. This tool works perfectly otherwise, but it prints and an error message, when it tries to execute `udevadm`.