### PR TITLE
busybox compatibility changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Update apt
         run: sudo apt-get update -q
       - name: Install dependencies
-        run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install tox lvm2 fdisk gdisk qemu-utils
+        run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install tox lvm2 fdisk gdisk qemu-utils busybox
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Run tox
@@ -17,3 +17,11 @@ jobs:
       - name: Run tests
         # SKIP growpart-lvm test that does not work on github c-i
         run: sudo SKIP=growpart-lvm PATH=$PWD/bin:$PATH ./test/run-all
+      - name: Run tests against BusyBox-based minimal environment
+        run: |
+          mkdir /tmp/busybox-bin
+          busybox --install -s /tmp/busybox-bin
+          ln -s $(command -v flock mkfs.ext4 qemu-img qemu-nbd resize2fs sfdisk sgdisk) /tmp/busybox-bin
+          # Skip growpart: needs BusyBox >= 1.31, not available in Ubuntu yet.
+          # Skip mic: needs BusyBox >= 1.31, not available in Ubuntu yet.
+          sudo SKIP=mic,growpart,growpart-lvm PATH=$PWD/bin:/tmp/busybox-bin ./test/run-all

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,14 +6,23 @@ jobs:
   tox:
     runs-on: ubuntu-18.04
     steps:
-      - name: Update apt
-        run: sudo apt-get update -q
       - name: Install dependencies
-        run: sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install tox lvm2 fdisk gdisk qemu-utils busybox
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Run tox
         run: tox
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install lvm2 fdisk gdisk qemu-utils busybox
+      - name: Git checkout
+        uses: actions/checkout@v2
       - name: Run tests
         # SKIP growpart-lvm test that does not work on github c-i
         run: sudo SKIP=growpart-lvm PATH=$PWD/bin:$PATH ./test/run-all

--- a/bin/cloud-localds
+++ b/bin/cloud-localds
@@ -67,8 +67,8 @@ has_cmd() {
 short_opts="hH:i:d:f:m:N:o:V:v"
 long_opts="disk-format:,dsmode:,filesystem:,help,hostname:,interfaces:,"
 long_opts="${long_opts}network-config:,output:,vendor-data:,verbose"
-getopt_out=$(getopt --name "${0##*/}" \
-	--options "${short_opts}" --long "${long_opts}" -- "$@") &&
+getopt_out=$(getopt -n "${0##*/}" \
+	-o "${short_opts}" -l "${long_opts}" -- "$@") &&
 	eval set -- "${getopt_out}" ||
 	bad_Usage
 
@@ -237,7 +237,7 @@ case "$filesystem" in
 			{ cat "$TEMP_D/err" 1>&2; fail "failed to genisoimage"; }
 		;;
 	vfat)
-		truncate --size 128K "$img" || fail "failed truncate image"
+		truncate -s 128K "$img" || fail "failed truncate image"
 		out=$(mkfs.vfat -n cidata "$img" 2>&1) ||
 			{ error "failed: mkfs.vfat -n cidata $img"; error "$out"; }
 		mcopy -oi "$img" "${files[@]}" :: ||

--- a/bin/mount-image-callback
+++ b/bin/mount-image-callback
@@ -352,8 +352,8 @@ mount_callback_umount() {
 
 	short_opts="Cdhm:P:psSv"
 	long_opts="cd-mountpoint,dev,help,format:,mountpoint:,overlay,partition:,proc,read-only,sys,system-mounts,system-resolvconf,verbose"
-	getopt_out=$(getopt --name "${0##*/}" \
-		--options "${short_opts}" --long "${long_opts}" -- "$@") &&
+	getopt_out=$(getopt -n "${0##*/}" \
+		-o "${short_opts}" -l "${long_opts}" -- "$@") &&
 		eval set -- "${getopt_out}" ||
 		{ bad_Usage; return 1; }
 
@@ -508,7 +508,7 @@ mount_callback_umount() {
 
 	if ${system_resolvconf}; then
 		local rcf="$mp/etc/resolv.conf"
-		cmp --quiet "/etc/resolv.conf" "$rcf" >/dev/null ||
+		cmp -s "/etc/resolv.conf" "$rcf" >/dev/null ||
 			error "WARN: /etc/resolv.conf changed in image!"
 		rm "$rcf" &&
 			{ [ -z "$ORIG_RESOLVCONF" ] || mv "$ORIG_RESOLVCONF" "$rcf"; } ||

--- a/bin/mount-image-callback
+++ b/bin/mount-image-callback
@@ -120,12 +120,11 @@ do_umounts() {
 cleanup() {
 	if [ "${#UMOUNTS[@]}" -ne 0 ]; then
 		debug 2 "umounts: ${UMOUNTS[*]}"
-		do_umounts "${UMOUNTS[@]}"
+		do_umounts "${UMOUNTS[@]}" ||
+			{ error "failed cleaning up mounts"; return 1; }
 	fi
 	disconnect_qemu
-	[ -z "${TEMP_D}" -o ! -d "${TEMP_D}" ] ||
-		rm --one-file-system -Rf "${TEMP_D}" ||
-		error "removal of temp dir failed!"
+	rm -Rf "$TEMP_D" || error "removal of temp dir failed!"
 }
 
 debug() {

--- a/bin/resize-part-image
+++ b/bin/resize-part-image
@@ -57,7 +57,7 @@ xtruncate() {
 		truncate "${@}"
 	else
 		local size=${1} file=${2} blk=""
-		size=${size#--size=}
+		size=${size#-s }
 		# this is a poor mans truncate supporting whatever human2bytes supports
 		human2bytes "${size}" && blk=$((${_RET}/512)) &&
 			dd if=/dev/zero of="${file}" obs=512 seek=${blk} count=0 2>/dev/null
@@ -135,14 +135,14 @@ runcmd "${verbose}" e2fsck -fp "${new}" ||
 	fail "failed to fsck ${new}"
 
 if [ "${old_size}" -lt "${new_size}" ]; then
-	xtruncate "--size=$size" "$new" || fail "failed to change size of ${new}"
+	xtruncate "-s $size" "$new" || fail "failed to change size of ${new}"
 fi
 
 runcmd "${verbose}" resize2fs "$new" "$size" ||
 	fail "failed to resize ${new} -> ${size}"
 
 if [ "${old_size}" -gt "${new_size}" ]; then
-	xtruncate "--size=$size" "$new" || fail "failed to change size of ${new}"
+	xtruncate "-s $size" "$new" || fail "failed to change size of ${new}"
 fi
 
 echo "resized ${new} to ${size}"

--- a/test/test-growpart
+++ b/test/test-growpart
@@ -20,14 +20,18 @@ cleanup() {
 		umount "$MP";
 	fi
 	if [ -n "$LODEV" ]; then
-		echo "losetup --detach $LODEV";
-		losetup --detach "$LODEV";
+		echo "losetup -d $LODEV";
+		losetup -d "$LODEV";
 	fi
 	[ ! -d "${TEMP_D}" ] || rm -Rf "${TEMP_D}"
 }
 rq() {
    local out="${TEMP_D}/out"
 	"$@" > "$out" 2>&1 || { echo "FAILED:" "$@"; cat "$out"; return 1; }
+}
+
+has_cmd() {
+	command -v "${1}" >/dev/null 2>&1
 }
 
 TEMP_D=$(mktemp -d ${TMPDIR:-/tmp}/${0##*/}.XXXXXX)
@@ -42,16 +46,17 @@ rm -f $img
 [ ! -e $mp ] || rmdir $mp || { echo "failed rmdir $mp"; exit 1; }
 mkdir $mp
 
-truncate --size $osize "$img"
+truncate -s $osize "$img"
 
 label_flag="--label=${PT_TYPE}"
 echo "2048," | rq sfdisk $label_flag --force --unit=S "$img"
 
-truncate --size "$size" "$img"
+truncate -s "$size" "$img"
 
-lodev=$(losetup --show --find --partscan "$img")
+lodev=$(losetup -f)
+losetup -P "$lodev" "$img"
 LODEV=$lodev
-udevadm settle
+! has_cmd udevadm || udevadm settle
 echo "set up $lodev"
 lodevpart="${lodev}p1"
 

--- a/test/test-growpart-fsimage
+++ b/test/test-growpart-fsimage
@@ -24,12 +24,12 @@ size=1000M
 osize=500M
 rm -f $img
 
-truncate --size $osize "$img"
+truncate -s $osize "$img"
 
 label_flag="--label=${PT_TYPE:-dos}"
 echo "2048," | rq sfdisk $label_flag --force --unit=S "$img"
 
-truncate --size "$size" "$img"
+truncate -s "$size" "$img"
 
 echo "==== before ===="
 sfdisk --list --unit=S "$img"

--- a/test/test-growpart-fsimage-middle
+++ b/test/test-growpart-fsimage-middle
@@ -46,7 +46,7 @@ CR='
 for resizer in sfdisk sgdisk; do
 	img="${TEMP_D}/disk-$resizer.img"
 	echo "====== Testing with resizer=$resizer ====="
-	rq truncate "--size=2G" "$img"
+	rq truncate -s 2G "$img"
 	( cd ${TEMP_D} && rq setup_img "${img##*/}" ) || fail "setup image $img"
 	echo "==== before ===="
 	( cd "${TEMP_D}" && sfdisk --dump "${img##*/}" )

--- a/test/test-growpart-lvm
+++ b/test/test-growpart-lvm
@@ -48,8 +48,8 @@ cleanup() {
 		rq lvm pvremove --force --yes "$PV"
 	fi
 	if [ -n "$LODEV" ]; then
-		echo "losetup --detach $LODEV";
-		losetup --detach "$LODEV";
+		echo "losetup -d $LODEV";
+		losetup -d "$LODEV";
 	fi
 	[ ! -d "${TEMP_D}" ] || rm -Rf "${TEMP_D}"
 }
@@ -67,6 +67,10 @@ get_vgsize() {
 	_RET="$out"
 }
 
+has_cmd() {
+	command -v "${1}" >/dev/null 2>&1
+}
+
 TEMP_D=$(mktemp -d ${TMPDIR:-/tmp}/${0##*/}.XXXXXX)
 trap cleanup EXIT
 
@@ -79,16 +83,17 @@ rm -f $img
 [ ! -e $mp ] || rmdir $mp || { echo "failed rmdir $mp"; exit 1; }
 mkdir $mp
 
-truncate --size $osize "$img"
+truncate -s $osize "$img"
 
 label_flag="--label=${PT_TYPE}"
 echo "2048," | rq sfdisk $label_flag --force --unit=S "$img"
 
-truncate --size "$size" "$img"
+truncate -s "$size" "$img"
 
-lodev=$(losetup --show --find --partscan "$img")
+lodev=$(losetup -f)
+losetup -P "$lodev" "$img"
 LODEV=$lodev
-udevadm settle
+! has_cmd udevadm || udevadm settle
 echo "set up $lodev"
 lodevpart="${lodev}p1"
 

--- a/test/test-growpart-overprovision
+++ b/test/test-growpart-overprovision
@@ -28,12 +28,12 @@ echo "Partitioning $PT_TYPE orig_size=$osize grow_size=$size, overprovisioning=$
 echo "growpart is $(which growpart)"
 rm -f $img
 
-truncate --size $osize "$img"
+truncate -s $osize "$img"
 
 label_flag="--label=${PT_TYPE}"
 echo "2048," | rq sfdisk $label_flag --force --unit=S "$img"
 
-truncate --size "$size" "$img"
+truncate -s "$size" "$img"
 
 echo "==== before ===="
 sfdisk --list --unit=S "$img"

--- a/test/test-growpart-start-matches-size
+++ b/test/test-growpart-start-matches-size
@@ -62,7 +62,7 @@ test_resize () {
         cd ${TEMP_D}
         echo "$expected" > partitions.expected
 
-        rq truncate "--size=2G" disk.img
+        rq truncate -s 2G disk.img
         rq setup_image || fail "setup image $img"
 
         sfdisk --dump disk.img > partitions.before

--- a/test/test-mic
+++ b/test/test-mic
@@ -78,8 +78,8 @@ echo "partition 2" > "$pt2_d/info.txt"
 ## Create 2 un-partitioned images, put a filesystem on them.
 ## And then mount them write a file, and then mount and
 ## read the file to verify its there.
-truncate "--size=$pt1_size" "$pt1"
-truncate "--size=$pt2_size" "$pt2"
+truncate -s "$pt1_size" "$pt1"
+truncate -s "$pt2_size" "$pt2"
 rq mkfs.ext4 -F "${pt1}"
 rq mkfs.ext4 -F "${pt2}"
 
@@ -160,8 +160,8 @@ mount-image-callback --read-only --cd -- "$pt1" sh -c '
 ## Stage 2
 ## Create a full disk image with those 2 partition images inside
 ## and a partition table that points to them.  Do one for MBR and GPT.
-truncate "--size=$prept_size" "$prept"
-truncate "--size=$postpt_size" "$postpt"
+truncate -s "$prept_size" "$prept"
+truncate -s "$postpt_size" "$postpt"
 
 msg "writing hunks to disk image ${img_mbr}"
 for hunk in "$prept" "$pt1" "$pt2" "$postpt"; do

--- a/tools/make-short-partition
+++ b/tools/make-short-partition
@@ -10,7 +10,7 @@ set -e
 fail() { echo "$@" 1>&2; exit 1; }
 
 if [ ! -e "$disk" ]; then
-	truncate --size 1G "$disk"
+	truncate -s 1G "$disk"
 fi
 
 if [ -b "$disk" ]; then


### PR DESCRIPTION
This patch replaces long options for cmp, getopt, and truncate with
short options that are supported by both Busybox's implementation
and also the full implementations.