### PR TITLE
growpart: use pt_size_bytes when partition cannot be grown

### DIFF
--- a/bin/growpart
+++ b/bin/growpart
@@ -301,7 +301,7 @@ resize_sfdisk() {
 	local mbr_max_512="4294967296"
 
 	local pt_start pt_size pt_end max_end new_size change_info dpart
-	local sector_num sector_size disk_size tot out
+	local sector_num sector_size disk_size pt_size_bytes tot out
 	local excess_sectors free_percent_sectors remaining_free_sectors
 
 	LANG=C rqe sfd_list sfdisk --list --unit=S "$DISK" >"$tmp" ||
@@ -444,10 +444,12 @@ resize_sfdisk() {
 		fi
 	fi
 
+	pt_size_bytes=$((${pt_size}*${sector_size}))
+
 	debug 1 "max_end=${max_end} tot=${sector_num} pt_end=${pt_end}" \
-		"pt_start=${pt_start} pt_size=${pt_size}"
+		"pt_start=${pt_start} pt_size=${pt_size} pt_size_bytes=${pt_size_bytes}"
 	[ $((${pt_end})) -eq ${max_end} ] && {
-		nochange "partition ${PART} is size ${pt_size}. it cannot be grown"
+		nochange "partition ${PART} size is ${pt_size_bytes} bytes (${pt_size} sectors of ${sector_size}). it cannot be grown"
 		return
 	}
 	[ $((${pt_end}+(${FUDGE}/$sector_size))) -gt ${max_end} ] && {
@@ -535,7 +537,7 @@ resize_sgdisk() {
 	local dev="disk=${DISK} partition=${PART}"
 
 	local pt_start pt_end pt_size last pt_max code guid name new_size
-	local old new change_info sector_size
+	local old new change_info sector_size pt_size_bytes
 
 	# Dump the original partition information and details to disk. This is
 	# used in case something goes wrong and human interaction is required
@@ -598,12 +600,14 @@ resize_sgdisk() {
 		"${pt_data}") && [ -n "${pt_max}" ] ||
 		fail "${dev}: failed to find max end sector"
 
+	pt_size_bytes=$((${pt_size}*${sector_size}))
+
 	debug 1 "${dev}: pt_start=${pt_start} pt_end=${pt_end}" \
-		"pt_size=${pt_size} pt_max=${pt_max} last=${last}"
+		"pt_size=${pt_size} pt_max=${pt_max} last=${last} pt_size_bytes=${pt_size_bytes}"
 
 	# Check if the partition can be grown
 	[ "${pt_end}" -eq "${pt_max}" ] && {
-		nochange "${dev}: size=${pt_size}, it cannot be grown"
+		nochange "${dev}: size=${pt_size_bytes} bytes (${pt_size} sectors of ${sector_size}), it cannot be grown"
 		return
 	}
 	[ "$((${pt_end} + ${FUDGE}/${sector_size}))" -gt "${pt_max}" ] && {


### PR DESCRIPTION
When partition cannot be grown, it is not straightforward to
understand the output.

With the patch:
$ sudo /tmp/growpart /dev/nvme0n1 2
NOCHANGE: partition 2 size is 17177755136 bytes (33550303 sectors of 512). it cannot be grown

Without the patch:
$ sudo growpart  /dev/nvme0n1 2
NOCHANGE: partition 2 is size 33550303. it cannot be grown

Signed-off-by: Xiao Liang <xiliang@redhat.com>