### PR TITLE
Fix growpart error with older blkid versions

### DIFF
--- a/bin/growpart
+++ b/bin/growpart
@@ -825,7 +825,7 @@ resize_sfdisk_dos() {
 
 get_table_format() {
 	local out="" disk="$1"
-	if has_cmd blkid && blkid --version | grep -q util-linux &&
+	if has_cmd blkid && blkid -V | grep -q util-linux &&
 		out=$(blkid -o value -s PTTYPE "$disk") &&
 		[ "$out" = "dos" -o "$out" = "gpt" ]; then
 		_RET="$out"


### PR DESCRIPTION
Certain older distributions (e.g. CentOS 7.9) include outdated versions (from 2013) of `blkid`.
Because [long options were added in 2017](https://github.com/util-linux/util-linux/commit/15a74f755a32a9458a68526d7591f8ccb9204e63), using the "original", short form to check the version would make this script work with these `blkid` versions instead of failing with `blkid: invalid option -- '-'`