### PR TITLE
Make GH Actions work again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run tox
         run: tox
   test:
@@ -22,7 +22,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install lvm2 fdisk gdisk qemu-utils busybox
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run tests
         # SKIP growpart-lvm test that does not work on github c-i
         run: sudo SKIP=growpart-lvm PATH=$PWD/bin:$PATH ./test/run-all

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   tox:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install dependencies
         run: |
@@ -15,7 +15,7 @@ jobs:
       - name: Run tox
         run: tox
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
- Switch to latest LTS Ubuntu runner image
- Use latest version of Checkout GitHub Action (makes those deprecated Nodejs warnings disappear)