### PR TITLE
[WIP] ec2metadata: Add support for `--tags`

### DIFF
--- a/bin/ec2metadata
+++ b/bin/ec2metadata
@@ -35,7 +35,7 @@ except ImportError:
 
 
 instdata_host = "169.254.169.254"
-instdata_ver = "2009-04-04"
+instdata_ver = "latest"
 instdata_url = "http://%s/%s" % (instdata_host, instdata_ver)
 
 TOKEN_TTL_SECONDS = 21600
@@ -84,6 +84,8 @@ Options:
     --profile               display the instance profile
     --instance-action       display the instance-action
 
+    --tags                  display the instance tags (if allowed in metadata)
+
     --public-keys           display the openssh public keys
     --user-data             display the user data (not actually metadata)
 
@@ -99,7 +101,7 @@ METAOPTS = ['ami-id', 'ami-launch-index', 'ami-manifest-path',
             'profile', 'product-codes', 'public-hostname', 'public-ipv4',
             'public-keys', 'ramdisk-id', 'reservation-id', 'security-groups',
             'user-data', 'availability-zone-id', 'region', 'host-id',
-            'group-name', 'partition-number']
+            'group-name', 'partition-number', 'tags']
 
 binstdout = os.fdopen(sys.stdout.fileno(), 'wb')
 
@@ -188,6 +190,20 @@ class EC2Metadata:  # pylint: disable=R0903
                 'partition-number',
                 ]:
             return self._get('meta-data/placement/' + metaopt)
+
+        if metaopt == 'tags':
+            data = self._get('meta-data/tags/instance/')
+            if data is None:
+                return None
+
+            tagids = [line.rstrip() for line in data.splitlines()]
+
+            tags = {}
+            for tagid in tagids:
+                uri = 'meta-data/tags/instance/%s' % tagid
+                tags[tagid]=self._get(uri).rstrip()
+
+            return tags
 
         if metaopt == 'public-keys':
             data = self._get('meta-data/public-keys')


### PR DESCRIPTION
Metadata tag support was added to the EC2 metadata API in 2022. As per the relevant [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/work-with-tags-in-IMDS.html#retrieve-tags-from-IMDS), both IMDS  version 2 and version 1 support exists.

I've used that to implement support for `--tags` to return a dict, similar to the list returned by `--public-keys`.

However, before this is merged, I request a quick review to answer whether the output should be 
- a python dictonary as is
  ```
  {'App': 'cardprocessor', 'Domain': 'stage-cardprocessor.sabpaisa.in', 'Name': 'cardprocessor-asg-member', 'aws:autoscaling:groupName': 'cardprocessor-autoscaling-group', 'aws:ec2launchtemplate:id': 'lt-0c7210c3de4129ea6', 'aws:ec2launchtemplate:version': '4'}
  ```
- A json dict
  ```
  {"App": "cardprocessor", "Domain": "stage-cardprocessor.sabpaisa.in", "Name": "cardprocessor-asg-member", "aws:autoscaling:groupName": "cardprocessor-autoscaling-group", "aws:ec2launchtemplate:id": "lt-0c7210c3de4129ea6", "aws:ec2launchtemplate:version": "4"}
  ```
- A flat  `tag: value`  list like default output of `ec2metadata`:
  ```
  Name: myasg-member
  aws:autoscaling:groupName: myasg
  aws:ec2launchtemplate:id: lt-deadbea1b00b10b155ad
  ```
- A list as above, but with a `tag:` prefix:
  ```
  tag:Name: myasg-member
  tag:aws:autoscaling:groupName: myasg
  tag:aws:ec2launchtemplate:id: lt-deadbea1b00b10b155ad
  ```
- Something else better than all the above, which I couldn't figure.


NOTE: I have signed the CLA already