### PR TITLE
Update repository location (Launchpad -> GitHub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The package is also available in Alpine and Arch as `cloud-utils`.
 
 ## Getting help
 
-If you find a bug or issue please report it on the upstream [Launchpad project](https://bugs.launchpad.net/cloud-utils/+filebug).
+If you find a bug or issue please report it on the upstream [GitHub project](https://github.com/canonical/cloud-utils).
 
 ## License
 

--- a/debian/README.source
+++ b/debian/README.source
@@ -1,5 +1,5 @@
 This is the cloud-utils ubuntu packaging branch.  It comes from:
- git clone https://git.launchpad.net/cloud-utils
+ git clone https://github.com/canonical/cloud-utils
 
 The upstream (master) branch does not include debian/changelog but it
 can built with ./tools/build-deb.

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper-compat (= 13), dh-python, python3
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
-Homepage: https://launchpad.net/cloud-utils
+Homepage: https://github.com/canonical/cloud-utils
 Vcs-Browser: https://github.com/canonical/cloud-utils
 Vcs-Git: https://github.com/canonical/cloud-utils.git
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: cloud-utils
-Source: https://code.launchpad.net/cloud-utils
+Source: https://github.com/canonical/cloud-utils
 Upstream-Contact: Scott Moser <scott.moser@canonical.com>
 
 Files: *


### PR DESCRIPTION
The migration happened back in 2022, but links across the projects were not properly updated.