### PR TITLE
README: drop reference to ubuntu-cloudimage-query

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The package is also available in Alpine and Arch as `cloud-utils`.
 * `growpart` - rewrite partition table so that partition takes up all the space it can
 * `mount-image-callback` - mount a file to a temporary mount point and then invoke the provided cmd with args
 * `resize-part-image` - resize a partition image and contained filesystem to a new size
-* `ubuntu-cloudimage-query` - get the latest Ubuntu AWS AMI meeting certain criteria
 * `vcs-run` - obtain a repository and execute a command with arguments
 * `write-mime-multipart` - utility for creating mime-multipart files, likely for use via user data and cloud-init
 


### PR DESCRIPTION
The ubuntu-cloudimg-query tool has been dropped in version 0.34, but a reference to it survived in `README.md` due to it being misspelled as ubuntu-cloudimage-query.